### PR TITLE
Fix URL and wordplate/framework version up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "wordplate/framework": "^4.3"
+        "wordplate/framework": "^6.0"
     },
     "config": {
         "preferred-install": "dist"

--- a/multisite.php
+++ b/multisite.php
@@ -47,7 +47,7 @@ function multisite(string $url): string
     $directory = env('WP_DIR', 'wordpress');
 
     foreach ($urls_to_fix as  $maybe_fix_url) {
-        $fixed_wp_url = '/'.$directory.'/'.$maybe_fix_url;
+        $fixed_wp_url = $directory.'/'.$maybe_fix_url;
 
         if (false !== stripos($url, $maybe_fix_url) && false === stripos($url, $fixed_wp_url)) {
             $url = str_replace($maybe_fix_url, $fixed_wp_url, $url);


### PR DESCRIPTION
1. Fix double forward slash `/` for admin URL base
2. Increase composer requirement for wordplate/framework to ^6.0